### PR TITLE
Remove TyIdents

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -193,7 +193,7 @@ pub enum ExprKind {
     Lambda(Vec<Ident>, ExecLoc, Ty, Box<Expr>),
     // A function that accepts something of the specified kind as an argument.
     // (x : kind) [exec]-> { e }
-    DepLambda(TyIdent, ExecLoc, Box<Expr>),
+    DepLambda(IdentKinded, ExecLoc, Box<Expr>),
     // Function application
     // e_f(e_1, ..., e_n)
     App(Box<Expr>, Vec<Expr>),

--- a/src/ty_check/mod.rs
+++ b/src/ty_check/mod.rs
@@ -286,7 +286,7 @@ fn ty_check_dep_app(
     }
     let df_ty_ctx = ty_check_expr(gl_ctx, kind_ctx, ty_ctx, exec, df)?;
     if let Ty::DepFn(param, _, _, out_ty) = df.ty.as_ref().unwrap() {
-        check_arg_has_correct_kind(&param.kind(), kv)?;
+        check_arg_has_correct_kind(&param.kind, kv)?;
         Ok((df_ty_ctx, *out_ty.clone()))
     } else {
         Err(

--- a/src/ty_check/subty_check.rs
+++ b/src/ty_check/subty_check.rs
@@ -6,7 +6,7 @@ use super::ty_ctx::TyCtx;
 
 use super::ErrMsg;
 use crate::ast::ty::*;
-use crate::ast::PlaceExpr;
+use crate::ast::{Ident, PlaceExpr};
 use std::collections::HashSet;
 
 // τ1 is subtype of τ2 under Δ and Γ, producing Γ′
@@ -173,7 +173,7 @@ fn outl_check_val_ident_prv(
     kind_ctx: &KindCtx,
     ty_ctx: TyCtx,
     longer_val: &str,
-    shorter_ident: &TyIdent,
+    shorter_ident: &Ident,
 ) -> Result<TyCtx, String> {
     // TODO how could the set ever be empty?
     let loan_set = ty_ctx.loans_for_prv(longer_val)?;
@@ -201,7 +201,7 @@ fn borrowed_pl_expr_no_ref_to_existing_pl(ty_ctx: &TyCtx, loan_set: &HashSet<Loa
 fn outl_check_ident_val_prv(
     kind_ctx: &KindCtx,
     ty_ctx: TyCtx,
-    longer_ident: &TyIdent,
+    longer_ident: &Ident,
     shorter_val: &str,
 ) -> Result<TyCtx, String> {
     if kind_ctx.ident_of_kind_exists(longer_ident, Kind::Provenance)

--- a/tests/basic_syntax.rs
+++ b/tests/basic_syntax.rs
@@ -602,12 +602,11 @@ fn function_decl_reference_params_example() {
     // }
     use ExecLoc::GpuGroup;
 
-    let r1 = prov_ident("'r1");
     let gpu_group_f =
         fdef("gpu_group_f",
              vec![("'r1", Kind::Provenance), ("'r2", Kind::Provenance)],
              vec![("p1",
-                    &ref_ty(&Provenance::Ident(r1), Shrd, &GpuShared, &i32)),
+                    &ref_ty(&Provenance::Ident(Ident::new("'r1")), Shrd, &GpuShared, &i32)),
                    ("p2",
                     &at_ty(&arr_ty(Nat::Lit(3), &i32), &GpuGlobal))],
              &unit_ty,
@@ -634,13 +633,13 @@ fn function_decl_reference_params_example() {
 
 mod copy_to_gpu {
     use descend::ast::ty::Memory::GpuGlobal;
-    use descend::ast::ty::{ExecLoc, FrameExpr, FrameTyping, KindCtx, Kinded, Ty, TyIdent};
+    use descend::ast::ty::{ExecLoc, FrameExpr, FrameTyping, IdentKinded, Kind, KindCtx, Ty};
     use descend::ast::*;
     use descend::dsl::*;
     use descend::ty_check::ty_ctx::IdentTyped;
 
-    pub fn ty_ident() -> TyIdent {
-        Ty::new_ident("elem_ty")
+    pub fn ty_ident() -> IdentKinded {
+        IdentKinded::new(&Ident::new("elem_ty"), Kind::Ty)
     }
     pub fn kind_ctx() -> KindCtx {
         KindCtx::new().append_ty_idents(vec![ty_ident()])


### PR DESCRIPTION
Remove `TyIdent` and only use `Ident`. `Ident` is still a struct with the single field `name`, but the idea is to add `span` for error reporting.

The `DepLambda` expressions and `DepFn` types take values of `IdentKinded` instead of `TyIdent` now. The naming has been changed to be consistent with the naming for (normal) expression identifiers with a type `IdentTyped`.