### PR TITLE
Feature/configure clang format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 Cargo.lock
 /.vscode
 *.out
-.cargo
+.cargo/config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 /.vscode
 *.out
+.cargo

--- a/src/codegen/printer.rs
+++ b/src/codegen/printer.rs
@@ -4,7 +4,6 @@ use super::cu_ast::{
 use crate::codegen::cu_ast::{GpuAddrSpace, Lit};
 use std::fmt::Formatter;
 use std::env;
-use std::env::VarError;
 
 // function cuda_fmt takes Formatter and recursively formats
 // trait CudaFormat has function cuda_fmt so that cuda_fmt_vec can be implemented (alias for fmt_vec)

--- a/src/codegen/printer.rs
+++ b/src/codegen/printer.rs
@@ -3,6 +3,8 @@ use super::cu_ast::{
 };
 use crate::codegen::cu_ast::{GpuAddrSpace, Lit};
 use std::fmt::Formatter;
+use std::env;
+use std::env::VarError;
 
 // function cuda_fmt takes Formatter and recursively formats
 // trait CudaFormat has function cuda_fmt so that cuda_fmt_vec can be implemented (alias for fmt_vec)
@@ -23,9 +25,15 @@ pub(super) fn print(program: &[Item]) -> String {
 }
 
 fn clang_format(code: &str) -> String {
+    //If clang-format is not available for user, it's path can be set in this env Variable (e.g. in .cargo/config.toml)
+    let clang_format_path = match env::var("CLANG_FORMAT_PATH") {
+        Ok(path) => path,
+        Err(_) => String::from("clang-format")
+    };
+
     use std::io::Write;
     use std::process::{Command, Stdio};
-    let mut clang_fmt_cmd = Command::new("clang-format")
+    let mut clang_fmt_cmd = Command::new(clang_format_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION
Introduces a Rust Env Variable CLANG_FORMAT_PATH to be able to set an absolute Path for Clang-Format Command